### PR TITLE
Add hierarchical select support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mui-fieldmaker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Fieldmaker for Material UI",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/FieldMaker.component.js
+++ b/src/FieldMaker.component.js
@@ -1,8 +1,7 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import FIELD_MAKER_MAP from './FieldMaker.map';
-
+import React from 'react';
 import './FieldMaker.css';
+import FIELD_MAKER_MAP from './FieldMaker.map';
 
 const FieldMaker = ({ type, className, nonTrivialValue, ...otherProps }) => {
   const FieldComponent = FIELD_MAKER_MAP[type.toLowerCase()]

--- a/src/FieldMaker.map.js
+++ b/src/FieldMaker.map.js
@@ -1,15 +1,16 @@
-import StringComponent from './Types/String.component';
-import PasswordComponent from './Types/Password.component';
-import NumberComponent from './Types/Number.component';
 import BooleanComponent from './Types/Boolean.component';
-import SelectComponent from './Types/Select.component';
 import CheckboxComponent from './Types/Checkbox.component';
-import MultipleComponent from './Types/Multiple.component';
 import FileComponent from './Types/File.component';
 import GroupComponent from './Types/Group.component';
+import HierarchicalSelectComponent from './Types/HierarchicalSelect.component';
+import MultipleComponent from './Types/Multiple.component';
+import NumberComponent from './Types/Number.component';
+import NumberTypeaheadComponent from './Types/NumberTypeahead.component';
+import PasswordComponent from './Types/Password.component';
+import SelectComponent from './Types/Select.component';
+import StringComponent from './Types/String.component';
 import TagsComponent from './Types/Tags.component';
 import TypeaheadComponent from './Types/Typeahead.component';
-import NumberTypeaheadComponent from './Types/NumberTypeahead.component';
 
 const FIELD_MAKER_MAP = {
   string: StringComponent,
@@ -18,6 +19,7 @@ const FIELD_MAKER_MAP = {
   numeric: NumberComponent,
   boolean: BooleanComponent,
   select: SelectComponent,
+  hierarchicalselect: HierarchicalSelectComponent,
   group: GroupComponent,
   tags: TagsComponent,
   checkbox: CheckboxComponent,

--- a/src/Types/HierarchicalSelect.component.js
+++ b/src/Types/HierarchicalSelect.component.js
@@ -4,7 +4,7 @@ import SelectComponent from './Select.component';
 
 const HierarchicalSelectComponent = ({
   options,
-  selectHierarchy,
+  hierarchy,
   value,
   onChange,
   config,
@@ -20,15 +20,15 @@ const HierarchicalSelectComponent = ({
     onChange({ target: { value: updatedValue } });
   };
 
-  let selectsOutput = selectHierarchy.reduce(
+  let selectsOutput = hierarchy.reduce(
     ({ selects, selectOptions }, select) => {
-      let currentValue = value[select.key],
+      let currentValue = value[select.id],
         CurrentSelect = (
           <SelectComponent
             {...parentProps}
             {...select}
             onChange={onSelectChange(
-              select.key,
+              select.id,
               selectOptions.length &&
                 Number.isInteger(selectOptions[0][config.valueKey])
             )}
@@ -55,7 +55,7 @@ const HierarchicalSelectComponent = ({
 HierarchicalSelectComponent.defaultProps = {
   value: {},
   options: [],
-  selectHierarchy: [],
+  hierarchy: [],
   required: false,
   withPickOneOption: true,
   pickOneOptionValue: '',
@@ -75,7 +75,7 @@ HierarchicalSelectComponent.propTypes = {
   nonTrivialValue: PropTypes.bool,
   label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
-  selectHierarchy: PropTypes.array.isRequired,
+  hierarchy: PropTypes.array.isRequired,
 };
 
 export default HierarchicalSelectComponent;

--- a/src/Types/HierarchicalSelect.component.js
+++ b/src/Types/HierarchicalSelect.component.js
@@ -10,10 +10,13 @@ const HierarchicalSelectComponent = ({
   config,
   ...parentProps
 }) => {
-  const onSelectChange = (property) => ({
+  const onSelectChange = (property, isIntegerValue) => ({
     target: { value: propertyValue },
   }) => {
-    let updatedValue = { ...value, [property]: propertyValue };
+    let updatedValue = {
+      ...value,
+      [property]: isIntegerValue ? parseInt(propertyValue) : propertyValue,
+    };
     onChange({ target: { value: updatedValue } });
   };
 
@@ -24,7 +27,11 @@ const HierarchicalSelectComponent = ({
           <SelectComponent
             {...parentProps}
             {...select}
-            onChange={onSelectChange(select.key)}
+            onChange={onSelectChange(
+              select.key,
+              selectOptions.length &&
+                Number.isInteger(selectOptions[0][config.valueKey])
+            )}
             value={currentValue}
             options={selectOptions}
             config={config}

--- a/src/Types/HierarchicalSelect.component.js
+++ b/src/Types/HierarchicalSelect.component.js
@@ -1,0 +1,74 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import SelectComponent from './Select.component';
+
+const HierarchicalSelectComponent = ({
+  options,
+  selectHierarchy,
+  value,
+  onChange,
+  config,
+  ...parentProps
+}) => {
+  const onSelectChange = (property) => ({
+    target: { value: propertyValue },
+  }) => {
+    let updatedValue = { ...value, [property]: propertyValue };
+    onChange({ target: { value: updatedValue } });
+  };
+
+  let selectsOutput = selectHierarchy.reduce(
+    ({ selects, selectOptions }, select) => {
+      let currentValue = value[select.key],
+        CurrentSelect = (
+          <SelectComponent
+            {...parentProps}
+            {...select}
+            onChange={onSelectChange(select.key)}
+            value={currentValue}
+            options={selectOptions}
+            config={config}
+            disabled={!selectOptions || !selectOptions.length}
+          />
+        ),
+        currentValueOption = selectOptions.find((s) => s.id === currentValue),
+        nextSelectOptions =
+          (currentValueOption && currentValueOption.options) || [];
+      return {
+        selects: [...selects, CurrentSelect],
+        selectOptions: nextSelectOptions,
+      };
+    },
+    { selects: [], selectOptions: options }
+  );
+
+  return <React.Fragment>{selectsOutput.selects}</React.Fragment>;
+};
+
+HierarchicalSelectComponent.defaultProps = {
+  value: {},
+  options: [],
+  selectHierarchy: [],
+  required: false,
+  withPickOneOption: true,
+  pickOneOptionValue: '',
+  config: {
+    valueKey: 'id',
+    labelKey: 'name',
+  },
+};
+
+HierarchicalSelectComponent.propTypes = {
+  value: PropTypes.object,
+  options: PropTypes.array,
+  required: PropTypes.bool,
+  withPickOneOption: PropTypes.bool,
+  pickOneOptionValue: PropTypes.any,
+  config: PropTypes.object,
+  nonTrivialValue: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  selectHierarchy: PropTypes.array.isRequired,
+};
+
+export default HierarchicalSelectComponent;


### PR DESCRIPTION
For cases in which the options of one select depend on the value another select has (for example, state -> city, or make/brand -> model)